### PR TITLE
Resolução e explicação:

### DIFF
--- a/TestesUnitarios.Desafio.Tests/ValidacoesListaTests.cs
+++ b/TestesUnitarios.Desafio.Tests/ValidacoesListaTests.cs
@@ -1,95 +1,94 @@
+using System;
+using System.Collections.Generic;
 using TestesUnitarios.Desafio.Console.Services;
+using Xunit;
 
-namespace TestesUnitarios.Desafio.Tests;
-
-public class ValidacoesListaTests
+namespace TestesUnitarios.Desafio.Tests
 {
-    private ValidacoesLista _validacoes = new ValidacoesLista();
-
-    [Fact]
-    public void DeveRemoverNumerosNegativosDeUmaLista()
+    public class ValidacoesListaTests
     {
-        // Arrange
-        var lista = new List<int> { 5, -1, -8, 9 };
-        var resultadoEsperado = new List<int> { 5, 9 };
+        private ValidacoesLista _validacoes = new ValidacoesLista();
 
-        // Act
-        var resultado = _validacoes.RemoverNumerosNegativos(lista);
+        [Fact]
+        public void DeveRemoverNumerosNegativosDeUmaLista()
+        {
+            // Arrange
+            var lista = new List<int> { 5, -1, -8, 9 };
+            var resultadoEsperado = new List<int> { 5, 9 };
 
-        // Assert
-        Assert.Equal(resultadoEsperado, resultado);
-    }
+            // Act
+            var resultado = _validacoes.RemoverNumerosNegativos(lista);
 
-    [Fact]
-    public void DeveConterONumero9NaLista()
-    {
-        // Arrange
-        var lista = new List<int> { 5, -1, -8, 9 };
-        var numeroParaProcurar = 9;
+            // Assert
+            Assert.Equal(resultadoEsperado, resultado);
+        }
 
-        // Act
-        var resultado = _validacoes.ListaContemDeterminadoNumero(lista, numeroParaProcurar);
+        [Fact]
+        public void DeveConterONumero9NaLista()
+        {
+            // Arrange
+            var lista = new List<int> { 5, -1, -8, 9 };
+            var numeroParaProcurar = 9;
 
-        // Assert
-        Assert.True(resultado);
-    }
+            // Act
+            var resultado = _validacoes.ListaContemDeterminadoNumero(lista, numeroParaProcurar);
 
-    [Fact]
-    public void NaoDeveConterONumero10NaLista()
-    {
-        //TODO: Implementar método de teste
+            // Assert
+            Assert.True(resultado);
+        }
 
-        // Arrange
-        var lista = new List<int> { 5, -1, -8, 9 };
-        var numeroParaProcurar = 10;
+        [Fact]
+        public void NaoDeveConterONumero10NaLista()
+        {
+            // Arrange
+            var lista = new List<int> { 5, -1, -8, 9 };
+            var numeroParaProcurar = 10;
 
-        // Act
+            // Act
+            var resultado = _validacoes.ListaContemDeterminadoNumero(lista, numeroParaProcurar);
 
-        // Assert
-    }
+            // Assert
+            Assert.False(resultado);
+        }
 
-    //TODO: Corrigir a anotação [Fact]
-    public void DeveMultiplicarOsElementosDaListaPor2()
-    {
-        //TODO: Implementar método de teste
+        [Fact]
+        public void DeveMultiplicarOsElementosDaListaPor2()
+        {
+            // Arrange
+            var lista = new List<int> { 5, 7, 8, 9 };
+            var resultadoEsperado = new List<int> { 10, 14, 16, 18 };
 
-        // Arrange
-        var lista = new List<int> { 5, 7, 8, 9 };
-        var resultadoEsperado = new List<int> { 10, 14, 16, 18 };
-        
-        // Act
+            // Act
+            var resultado = _validacoes.MultiplicarNumerosLista(lista, 2);
 
-        // Assert
-    }
+            // Assert
+            Assert.Equal(resultadoEsperado, resultado);
+        }
 
-    [Fact]
-    public void DeveRetornar9ComoMaiorNumeroDaLista()
-    {
-        //TODO: Implementar método de teste
+        [Fact]
+        public void DeveRetornar9ComoMaiorNumeroDaLista()
+        {
+            // Arrange
+            var lista = new List<int> { 5, -1, -8, 9 };
 
-        // Arrange
-        var lista = new List<int> { 5, -1, -8, 9 };
+            // Act
+            var resultado = _validacoes.RetornarMaiorNumeroLista(lista);
 
-        // Act
+            // Assert
+            Assert.Equal(9, resultado);
+        }
 
-        // Assert
-        //TODO: Corrigir o Assert.Equal com base no retorno da chamada ao método
-        Assert.Equal(9, 9);
-    }
+        [Fact]
+        public void DeveRetornarOitoNegativoComoMenorNumeroDaLista()
+        {
+            // Arrange
+            var lista = new List<int> { 5, -1, -8, 9 };
 
-    [Fact]
-    public void DeveRetornarOitoNegativoComoMenorNumeroDaLista()
-    {
-        //TODO: Implementar método de teste
+            // Act
+            var resultado = _validacoes.RetornarMenorNumeroLista(lista);
 
-        // Arrange
-        var lista = new List<int> { 5, -1, -8, 9 };
-
-        // Act
-        var resultado = _validacoes.RetornarMenorNumeroLista(lista);
-
-        // Assert
-        //TODO: Corrigir o Assert.Equal com base no retorno da chamada ao método
-        Assert.Equal(-8, -8);
+            // Assert
+            Assert.Equal(-8, resultado);
+        }
     }
 }

--- a/TestesUnitarios.Desafio.Tests/ValidacoesListaTests.cs
+++ b/TestesUnitarios.Desafio.Tests/ValidacoesListaTests.cs
@@ -22,7 +22,6 @@ namespace TestesUnitarios.Desafio.Tests
             // Assert
             Assert.Equal(resultadoEsperado, resultado);
         }
-
         [Fact]
         public void DeveConterONumero9NaLista()
         {

--- a/TestesUnitarios.Desafio.Tests/ValidacoesStringTests.cs
+++ b/TestesUnitarios.Desafio.Tests/ValidacoesStringTests.cs
@@ -1,71 +1,66 @@
 using TestesUnitarios.Desafio.Console.Services;
+using Xunit;
 
-namespace TestesUnitarios.Desafio.Tests;
-
-public class ValidacoesStringTests
+namespace TestesUnitarios.Desafio.Tests
 {
-    private ValidacoesString _validacoes = new ValidacoesString();
-
-    [Fact]
-    public void DeveRetornar6QuantidadeCaracteresDaPalavraMatrix()
+    public class ValidacoesStringTests
     {
-        //TODO: Corrigir a variável "texto" e "resultadoEsperado" da seção Arrange
+        private ValidacoesString _validacoes = new ValidacoesString();
 
-        // Arrange
-        var texto = "a";
-        var resultadoEsperado = 0;
+        [Fact]
+        public void DeveRetornar6QuantidadeCaracteresDaPalavraMatrix()
+        {
+            // Arrange
+            var texto = "Matrix";
+            var resultadoEsperado = 6;
 
-        // Act
-        var resultado = _validacoes.RetornarQuantidadeCaracteres(texto);
+            // Act
+            var resultado = _validacoes.RetornarQuantidadeCaracteres(texto);
 
-        // Assert
-        Assert.Equal(resultadoEsperado, resultado);
-    }
+            // Assert
+            Assert.Equal(resultadoEsperado, resultado);
+        }
 
-    [Fact]
-    public void DeveContemAPalavraQualquerNoTexto()
-    {
-        // Arrange
-        var texto = "Esse é um texto qualquer";
-        var textoProcurado = "qualquer";
+        [Fact]
+        public void DeveContemAPalavraQualquerNoTexto()
+        {
+            // Arrange
+            var texto = "Esse é um texto qualquer";
+            var textoProcurado = "qualquer";
 
-        //TODO: Corrigir a chamada do método "ContemCaractere" da seção Act
-        // Act
-         _validacoes.ContemCaractere(texto, textoProcurado);
+            // Act
+            var resultado = _validacoes.ContemCaractere(texto, textoProcurado);
 
-        // Assert
-        //TODO: Corrigir o Assert.True com base no retorno da chamada ao método
-        Assert.True(true);
-    }
+            // Assert
+            Assert.True(resultado);
+        }
 
-    [Fact]
-    public void NaoDeveConterAPalavraTesteNoTexto()
-    {
-        // Arrange
-        var texto = "Esse é um texto qualquer";
-        var textoProcurado = "teste";
+        [Fact]
+        public void NaoDeveConterAPalavraTesteNoTexto()
+        {
+            // Arrange
+            var texto = "Esse é um texto qualquer";
+            var textoProcurado = "teste";
 
-        // Act
-        var resultado = _validacoes.ContemCaractere(texto, textoProcurado);
+            // Act
+            var resultado = _validacoes.ContemCaractere(texto, textoProcurado);
 
-        // Assert
-        //TODO: Corrigir o Assert.False com base no retorno da chamada ao método
-        Assert.False(true);
-    }
+            // Assert
+            Assert.False(resultado);
+        }
 
-    //TODO: Corrigir a anotação [Fact]
-    public void TextoDeveTerminarComAPalavraProcurado()
-    {
-        //TODO: Corrigir a variável "textoProcurado" seção Arrange
+        [Fact]
+        public void TextoDeveTerminarComAPalavraProcurado()
+        {
+            // Arrange
+            var texto = "Começo, meio e fim do texto procurado";
+            var textoProcurado = "procurado";
 
-        // Arrange
-        var texto = "Começo, meio e fim do texto procurado";
-        var textoProcurado = "teste";
+            // Act
+            var resultado = _validacoes.TextoTerminaCom(texto, textoProcurado);
 
-        // Act
-        var resultado = _validacoes.TextoTerminaCom(texto, textoProcurado);
-
-        // Assert
-        Assert.True(resultado);
+            // Assert
+            Assert.True(resultado);
+        }
     }
 }

--- a/TestesUnitarios.Desafio.Tests/ValidacoesStringTests.cs
+++ b/TestesUnitarios.Desafio.Tests/ValidacoesStringTests.cs
@@ -58,7 +58,7 @@ namespace TestesUnitarios.Desafio.Tests
 
             // Act
             var resultado = _validacoes.TextoTerminaCom(texto, textoProcurado);
-
+ 
             // Assert
             Assert.True(resultado);
         }


### PR DESCRIPTION
ValidacoesStringstests:

DeveRetornar6QuantidadeCaracteresDaPalavraMatrix:

- Arrange, o valor de resultadoEsperado foi corrigido para 6, que é o número de caracteres na palavra "Matrix".
- Act, a função correta RetornarQuantidadeCaracteres foi chamada com o texto apropriado.
-  Assert, a comparação foi corrigida para Assert.Equal(resultadoEsperado, resultado).

DeveContemAPalavraQualquerNoTexto:

- Arrange, o textoProcurado foi ajustado para "qualquer".
- Act, a função correta ContemCaractere foi chamada com os textos apropriados.
- Assert, a comparação foi corrigida para Assert.True(resultado).

NaoDeveConterAPalavraTesteNoTexto:

- Arrange, o textoProcurado foi ajustado para "teste".
- Act, a função correta ContemCaractere foi chamada com os textos apropriados.
- Assert, a comparação foi corrigida para Assert.False(resultado).

TextoDeveTerminarComAPalavraProcurado:

- Arrange, o textoProcurado foi ajustado para "procurado".
- Act, a função correta TextoTerminaCom foi chamada com os textos apropriados.
- Assert, a comparação foi corrigida para Assert.True(resultado).

ValidacoesListaTests:

DeveRemoverNumerosNegativosDeUmaLista:

- Act, a função correta RemoverNumerosNegativos foi chamada com a lista apropriada.
- Assert, a comparação foi corrigida para Assert.Equal(resultadoEsperado, resultado).

DeveConterONumero9NaLista:

- Act, a função correta ListaContemDeterminadoNumero foi chamada com a lista e o número apropriados.
- Assert, a comparação foi corrigida para Assert.True(resultado).

NaoDeveConterONumero10NaLista:

- Act, a função correta ListaContemDeterminadoNumero foi chamada com a lista e o número apropriados.
- Assert, a comparação foi corrigida para Assert.False(resultado).
DeveMultiplicarOsElementosDaListaPor2:

- Act, a função correta MultiplicarNumerosLista foi chamada com a lista e o número apropriados.
- Assert, a comparação foi corrigida para Assert.Equal(resultadoEsperado, resultado).

DeveRetornar9ComoMaiorNumeroDaLista:

- Act, a função correta RetornarMaiorNumeroLista foi chamada com a lista apropriada.
- Assert, a comparação foi corrigida para Assert.Equal(9, resultado).

DeveRetornarOitoNegativoComoMenorNumeroDaLista:

- Act, a função correta RetornarMenorNumeroLista foi chamada com a lista apropriada.
- Assert, a comparação foi corrigida para Assert.Equal(-8, resultado)
